### PR TITLE
Bridge now returns correct status code when a read is requested.

### DIFF
--- a/AXPB011/Application/Source/comms.c
+++ b/AXPB011/Application/Source/comms.c
@@ -271,7 +271,7 @@ uint32_t ReadAxiom(uint16_t addr, uint8_t *pbuf, uint32_t length)
             {
                 case I2CSTATUS_READWRITEOK:
                 {
-                    status = AXIOMCOMMS_WRITE_OK_NOREAD;
+                    status = AXIOMCOMMS_READWRITE_OK;
                     break;
                 }
 
@@ -302,7 +302,7 @@ uint32_t ReadAxiom(uint16_t addr, uint8_t *pbuf, uint32_t length)
             {
                 case SPISTATUS_READWRITEOK:
                 {
-                    status = AXIOMCOMMS_WRITE_OK_NOREAD;
+                    status = AXIOMCOMMS_READWRITE_OK;
                     break;
                 }
 


### PR DESCRIPTION
Was returning AXIOMCOMMS_WRITE_OK_NOREAD for a read, should have been returning AXIOMCOMMS_READWRITE_OK.