### PR TITLE
USB host detection improvements

### DIFF
--- a/AXPB011/Application/Include/init.h
+++ b/AXPB011/Application/Include/init.h
@@ -52,6 +52,9 @@
 #define USB_HOST_DETECTED   (1U)
 #define USB_HOST_ABSENT     (0U)
 
+#define RUN_INITIAL_SETUP   (1U)
+#define SKIP_INITIAL_SETUP  (0U)
+
 /*******************************************************************************
  * Exported Variables
  ******************************************************************************/
@@ -63,7 +66,7 @@ extern digitizer_fop_handler    g_digitizer_fops;
 /*******************************************************************************
  * Exported Functions
  ******************************************************************************/
-uint8_t DeviceInit(usb_core_driver *pDevice);
+uint8_t DeviceInit(usb_core_driver *pDevice, uint8_t SkipInitialSetup);
 void DeviceDeInit(usb_core_driver *pDevice, uint8_t disable_irq);
 						   
 /*******************************************************************************

--- a/AXPB011/Application/Source/_axpb011_main.c
+++ b/AXPB011/Application/Source/_axpb011_main.c
@@ -97,13 +97,12 @@ int main(void)
     uint8_t PressUSBReport[PRESS_IN_PACKET_SIZE]            = {0};
     uint8_t DigitizerUSBReport[DIGITIZER_IN_PACKET_SIZE]    = {0};
 
-    if (DeviceInit(&g_composite_hid_device) == USB_HOST_ABSENT)
+    uint8_t HostUSBState = DeviceInit(&g_composite_hid_device, RUN_INITIAL_SETUP);
+    while(HostUSBState == USB_HOST_ABSENT)
     {
-        for (;;)
-        {
-            // Do nothing, forever.
-            continue;
-        }
+        // Host wasn't detected, try again.
+        delay_1ms(500);
+        HostUSBState = DeviceInit(&g_composite_hid_device, SKIP_INITIAL_SETUP);
     }
 
     for (;;)

--- a/AXPB011/Application/Source/composite_usb_wrapper.c
+++ b/AXPB011/Application/Source/composite_usb_wrapper.c
@@ -66,7 +66,7 @@
 #define USBD_PID                (0x0000U)   // Updated during init
 
 #define DEVICE_FW_VERSION_MAJOR (0x01U)
-#define DEVICE_FW_VERSION_MINOR (0x04U)
+#define DEVICE_FW_VERSION_MINOR (0x05U)
 
 #define DEVICE_FW_VERSION       ((uint16_t)((DEVICE_FW_VERSION_MAJOR << 8U) | (DEVICE_FW_VERSION_MINOR)))
 


### PR DESCRIPTION
AXPB011 will now continually look for a USB host even after deciding there isn't one present.

This prevents the bridge from incorrectly deciding that no USB host is present if the USB cable is connected slowly (i.e. power is supplied a considerable time before the data pins).