### PR TITLE
Fixed hard-fault during USB re-enumeration after a host reboot

### DIFF
--- a/AXPB011/Application/Include/mode_control.h
+++ b/AXPB011/Application/Include/mode_control.h
@@ -53,6 +53,7 @@
 #define MODE_TBP_BASIC              (0x00u)
 #define MODE_ABSOLUTE_MOUSE         (0x01u)
 #define MODE_PARALLEL_DIGITIZER     (0x03u)
+#define MODE_UNKNOWN                (0xFFu)
 
 /*******************************************************************************
  * Exported Variables
@@ -64,7 +65,8 @@
  ******************************************************************************/
 void CheckBridgeMode(usb_core_driver *udev);
 void WriteBridgeMode(usb_core_driver *udev, uint8_t bridge_mode);
-uint8_t ReadBridgeMode(void);
+uint8_t ReadBridgeModeFromFlash(void);
+uint8_t GetBridgeMode(void);
 						   
 /*******************************************************************************
  * Macros

--- a/AXPB011/Application/Source/_axpb011_main.c
+++ b/AXPB011/Application/Source/_axpb011_main.c
@@ -206,7 +206,7 @@ static void RunProxy(usb_dev *udev, uint8_t *USBControl, uint8_t *USBPress, uint
                 {
                     PreparePressUSBReport(ProxyReport, USBPress);
 
-                    if ((ReadBridgeMode() == MODE_PARALLEL_DIGITIZER) || (ReadBridgeMode() == MODE_ABSOLUTE_MOUSE))
+                    if ((GetBridgeMode() == MODE_PARALLEL_DIGITIZER) || (GetBridgeMode() == MODE_ABSOLUTE_MOUSE))
                     {
                         PrepareDigitizerUSBReport(udev, ProxyReport, USBDigitizer);
                     }
@@ -226,7 +226,7 @@ static void RunProxy(usb_dev *udev, uint8_t *USBControl, uint8_t *USBPress, uint
                 {
                     PreparePressUSBReport(ProxyReport, USBPress);
 
-                    if ((ReadBridgeMode() == MODE_PARALLEL_DIGITIZER) || (ReadBridgeMode() == MODE_ABSOLUTE_MOUSE))
+                    if ((GetBridgeMode() == MODE_PARALLEL_DIGITIZER) || (GetBridgeMode() == MODE_ABSOLUTE_MOUSE))
                     {
                         PrepareDigitizerUSBReport(udev, ProxyReport, USBDigitizer);
                     }

--- a/AXPB011/Application/Source/command_processor.c
+++ b/AXPB011/Application/Source/command_processor.c
@@ -515,7 +515,7 @@ uint8_t ProcessTBPCommand(usb_core_driver *udev, uint8_t *pResponse, uint8_t whi
         case CMD_GET_BRIDGE_MODE:
         {
             pResponse[0] = CMD_GET_BRIDGE_MODE;
-            pResponse[1] = ReadBridgeMode();
+            pResponse[1] = GetBridgeMode();
             response_required = RESPONSE_REQUIRED;
             break;
         }

--- a/AXPB011/Application/Source/composite_usb_wrapper.c
+++ b/AXPB011/Application/Source/composite_usb_wrapper.c
@@ -425,7 +425,8 @@ static uint8_t hid_composite_init(usb_dev *udev, uint8_t config_index)
     usbd_generic_hid_cb.init(udev, config_index, &composite_config_desc.generic_epin, &composite_config_desc.generic_epout);
     usbd_press_hid_cb.init(udev, config_index, &composite_config_desc.press_epin, &composite_config_desc.press_epout);
 
-    uint8_t mode = ReadBridgeMode();
+    // TODO JC - reading the flash seems to be leading to a hardfault.
+    uint8_t mode = GetBridgeMode();
     if ((mode == MODE_ABSOLUTE_MOUSE) || (mode == MODE_PARALLEL_DIGITIZER))
     {
         usbd_digitizer_hid_cb.init(udev, config_index, &composite_config_desc.digitizer_epin, NULL);

--- a/AXPB011/Application/Source/digitizer_hid_itf.c
+++ b/AXPB011/Application/Source/digitizer_hid_itf.c
@@ -142,7 +142,7 @@ void PrepareDigitizerUSBReport(usb_dev *udev, uint8_t *pReport, uint8_t *pMsg)
 {
     if (CheckIfDigitizerUSBBlocked() == eDigitizerPacketsAllowed)
     {
-        switch (ReadBridgeMode())
+        switch (GetBridgeMode())
         {
             case MODE_PARALLEL_DIGITIZER:
             {
@@ -217,7 +217,7 @@ uint32_t GetDigitizerReportLength(void)
 {
     uint32_t length = 0;
 
-    switch (ReadBridgeMode())
+    switch (GetBridgeMode())
     {
         case MODE_PARALLEL_DIGITIZER:
         {

--- a/AXPB011/Application/Source/gd32f3x0_it.c
+++ b/AXPB011/Application/Source/gd32f3x0_it.c
@@ -105,6 +105,7 @@ void HardFault_Handler(void)
     /* if Hard Fault exception occurs, go to infinite loop */
     while (1)
     {
+        RestartBridge(&g_composite_hid_device);
     }
 }
 
@@ -119,6 +120,7 @@ void MemManage_Handler(void)
     /* if Memory Manage exception occurs, go to infinite loop */
     while (1)
     {
+        RestartBridge(&g_composite_hid_device);
     }
 }
 
@@ -133,6 +135,7 @@ void BusFault_Handler(void)
     /* if Bus Fault exception occurs, go to infinite loop */
     while (1)
     {
+        RestartBridge(&g_composite_hid_device);
     }
 }
 
@@ -147,6 +150,7 @@ void UsageFault_Handler(void)
     /* if Usage Fault exception occurs, go to infinite loop */
     while (1)
     {
+        RestartBridge(&g_composite_hid_device);
     }
 }
 

--- a/AXPB011/Application/Source/init.c
+++ b/AXPB011/Application/Source/init.c
@@ -458,7 +458,7 @@ static void USB_FS_DeInit(usb_core_driver *pDevice)
 
 static void ConfigureDescriptors(void)
 {
-    uint8_t bridge_mode = ReadBridgeMode();
+    uint8_t bridge_mode = GetBridgeMode();
 
     switch (bridge_mode)
     {

--- a/AXPB011/Application/Source/mode_control.c
+++ b/AXPB011/Application/Source/mode_control.c
@@ -52,7 +52,7 @@
 /*******************************************************************************
  * File Scope Variables
  ******************************************************************************/
-
+uint8_t g_bridge_mode = MODE_UNKNOWN;
 
 /*******************************************************************************
  * File Scope Constants
@@ -83,9 +83,9 @@
  */
 void CheckBridgeMode(usb_core_driver *udev)
 {
-    uint8_t option_byte = ReadBridgeMode();
+    g_bridge_mode = ReadBridgeModeFromFlash();
 
-    if ((option_byte == MODE_TBP_BASIC) || (option_byte == MODE_ABSOLUTE_MOUSE) || (option_byte == MODE_PARALLEL_DIGITIZER))
+    if ((g_bridge_mode == MODE_TBP_BASIC) || (g_bridge_mode == MODE_ABSOLUTE_MOUSE) || (g_bridge_mode == MODE_PARALLEL_DIGITIZER))
     {
         // Do nothing
     }
@@ -116,12 +116,20 @@ void WriteBridgeMode(usb_core_driver *udev, uint8_t bridge_mode)
 }
 
 /**
- * @brief Returns the general bridge mode from the option byte.
+ * @brief Reads the general bridge mode from the option byte.
  * @return  Current bridge mode stored in option byte flash area.
  */
-uint8_t ReadBridgeMode(void)
+uint8_t ReadBridgeModeFromFlash(void)
 {
     return ReadOptionByte(BRIDGE_MODE_ADDR);
+}
+
+/**
+ * @brief Returns the general bridge mode.
+ */
+uint8_t GetBridgeMode(void)
+{
+    return g_bridge_mode;
 }
 
 /*******************************************************************************

--- a/AXPB011/Peripherals/GD32F3x0_usbfs_library/device/class/hid/Digitizer/Source/digitizer_hid_core.c
+++ b/AXPB011/Peripherals/GD32F3x0_usbfs_library/device/class/hid/Digitizer/Source/digitizer_hid_core.c
@@ -567,7 +567,7 @@ static uint8_t digitizer_hid_req_handler(usb_dev *udev, usb_req *req)
     case USB_GET_DESCRIPTOR:
         if (USB_DESCTYPE_REPORT == (req->wValue >> 8U))
         {
-            switch (ReadBridgeMode())
+            switch (GetBridgeMode())
             {
                 case MODE_PARALLEL_DIGITIZER:
                 {


### PR DESCRIPTION
The option byte is now only read once after a reset and stores a RAM copy at boot.

Previously, every time the bridge mode was required the chip read from the option byte in flash. This resulted in a very rare hard-fault during a host reboot. The AXPB011 will also now reset whenever a hard fault is detected.