### PR TITLE
CODE-5474 I2C Timeout issue

### DIFF
--- a/AXPB011/Application/Source/i2c.c
+++ b/AXPB011/Application/Source/i2c.c
@@ -74,7 +74,7 @@ static uint32_t g_axiom_i2c_addr = 0;
  ******************************************************************************/
 #define I2C_PERIPH      (I2C0)
 
-#define I2C_MAX_TIMEOUT_COUNT   (10U)
+#define I2C_MAX_TIMEOUT_COUNT   (5000U) /*25ms*/
 #define I2C_SLEEP_US            (5U)
 
 #define STATUS_OK       (0x00U)


### PR DESCRIPTION
Extended I2C timeout from 50us to 25ms. 
This is slightly longer than aXiom was taking to respond to 00 00 3a 80 (read).